### PR TITLE
[SW-120][minor_changed]아이폰 가로모드 네비게이션 클릭 잘 안되는 이슈

### DIFF
--- a/front/src/spaceMain/spaceMain.css
+++ b/front/src/spaceMain/spaceMain.css
@@ -4,6 +4,7 @@ canvas {
   height: 92vh;
   /* for Iphone */
   height: calc(var(--vh) * 92);
+  height: calc(var(--vh) * 92 - env(safe-area-inset-bottom) - 12px);
   display: block;
 }
 
@@ -17,6 +18,7 @@ canvas {
   height: 92vh;
   /* for Iphone */
   height: calc(var(--vh) * 92);
+  height: calc(var(--vh) * 92 - env(safe-area-inset-bottom) - 12px);
   z-index: 10;
   overflow: hidden;
 }
@@ -29,12 +31,13 @@ canvas {
 .navbar {
   height: 8vh;
   /* for Iphone */
-  height: calc(var(--vh) * 8);
+  height: calc(var(--vh) * 8 + env(safe-area-inset-bottom) + 12px);
   display: flex;
   align-items: center;
   justify-content: space-between;
   background-color: gainsboro;
   padding: 8px 12px;
+  padding-bottom: calc(env(safe-area-inset-bottom) + 12px);
   font-size: 3vh;
   /* for Iphone */
   font-size: calc(var(--vh) * 3);


### PR DESCRIPTION
아이폰 가로모드에서 하단의 네비게이션바와 홈으로 나가는 바가 겹치는 현상 해결