### PR TITLE
Sw 145/messenger

### DIFF
--- a/front/src/components/Messenger.tsx
+++ b/front/src/components/Messenger.tsx
@@ -2,7 +2,14 @@ import React, {FormEvent} from 'react';
 import {Menu} from 'antd';
 import {LeftCircleFilled} from '@ant-design/icons';
 
+export interface Message {
+  type: string;
+  nickname: string;
+  data: string;
+}
+
 export interface MessengerProps {
+  messages: string[] | undefined;
   onClickPrevious: () => void;
   message: string;
   onMessageInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -22,6 +29,13 @@ export function Messenger(props: MessengerProps): JSX.Element {
       </Menu.Item>
       <Menu.Divider></Menu.Divider>
       <Menu.Item key="1">
+        <>
+          {props.messages?.map((message, index) => {
+            return <div key={index}>{message}</div>;
+          })}
+        </>
+      </Menu.Item>
+      <Menu.Item key="2">
         <form onSubmit={props.onSendMessage}>
           <input
             type="text"

--- a/front/src/components/Messenger.tsx
+++ b/front/src/components/Messenger.tsx
@@ -2,11 +2,11 @@ import React from 'react';
 import {Menu} from 'antd';
 import {LeftCircleFilled} from '@ant-design/icons';
 
-export interface MessageProps {
+export interface MessengerProps {
   onClickPrevious: () => void;
 }
 
-export function Message(props: MessageProps): JSX.Element {
+export function Messenger(props: MessengerProps): JSX.Element {
   return (
     <Menu className="message_drop_down">
       <Menu.Item key="0">

--- a/front/src/components/Messenger.tsx
+++ b/front/src/components/Messenger.tsx
@@ -1,9 +1,12 @@
-import React from 'react';
+import React, {FormEvent} from 'react';
 import {Menu} from 'antd';
 import {LeftCircleFilled} from '@ant-design/icons';
 
 export interface MessengerProps {
   onClickPrevious: () => void;
+  message: string;
+  onMessageInput: (e: React.ChangeEvent<HTMLInputElement>) => void;
+  onSendMessage: (e: FormEvent) => void;
 }
 
 export function Messenger(props: MessengerProps): JSX.Element {
@@ -18,7 +21,17 @@ export function Messenger(props: MessengerProps): JSX.Element {
         </div>
       </Menu.Item>
       <Menu.Divider></Menu.Divider>
-      <Menu.Item key="1">구현 예정</Menu.Item>
+      <Menu.Item key="1">
+        <form onSubmit={props.onSendMessage}>
+          <input
+            type="text"
+            placeholder="메시지를 입력하세요"
+            onChange={props.onMessageInput}
+            value={props.message}
+          />
+          <button>전송</button>
+        </form>
+      </Menu.Item>
     </Menu>
   );
 }

--- a/front/src/components/Navigation.tsx
+++ b/front/src/components/Navigation.tsx
@@ -11,6 +11,7 @@ import PeerManager from '../utils/RTCGameUtils';
 import {AvatarImageEnum} from '../utils/ImageMetaData';
 import {message} from 'antd';
 import {UserInfo} from './UserList';
+import {Message} from './Messenger';
 
 interface NavigationProps {
   peerManager: PeerManager;
@@ -39,7 +40,14 @@ function Navigation(props: NavigationProps): JSX.Element {
       peer.transmitUsingDataChannel(message);
     });
   };
-
+  const setOnMessageCallback = (
+    onMessageCallback: (message: Message) => void,
+  ) => {
+    props.peerManager.setOnMessageCallback(onMessageCallback);
+  };
+  const getMyNickname = (): string => {
+    return props.peerManager.me.nickname;
+  };
   const getUsers = (): UserInfo[] => {
     const result: UserInfo[] = [
       {
@@ -88,11 +96,12 @@ function Navigation(props: NavigationProps): JSX.Element {
       </div>
       <div className="navbar_right">
         <Panel
+          getMyNickname={getMyNickname}
           getUsers={getUsers}
           roomId={props.peerManager.roomID}
-          peers={props.peerManager.peers}
           onCopy={onCopy}
           sendMessage={sendMessage}
+          setOnMessageCallback={setOnMessageCallback}
         />
       </div>
     </nav>

--- a/front/src/components/Navigation.tsx
+++ b/front/src/components/Navigation.tsx
@@ -34,6 +34,11 @@ function Navigation(props: NavigationProps): JSX.Element {
   const onCopy = () => {
     message.info('클립보드에 복사 되었습니다!');
   };
+  const sendMessage = (message: string) => {
+    props.peerManager.peers.forEach(peer => {
+      peer.transmitUsingDataChannel(message);
+    });
+  };
 
   const getUsers = (): UserInfo[] => {
     const result: UserInfo[] = [
@@ -87,6 +92,7 @@ function Navigation(props: NavigationProps): JSX.Element {
           roomId={props.peerManager.roomID}
           peers={props.peerManager.peers}
           onCopy={onCopy}
+          sendMessage={sendMessage}
         />
       </div>
     </nav>

--- a/front/src/components/Panel.tsx
+++ b/front/src/components/Panel.tsx
@@ -12,6 +12,7 @@ export interface PanelProps {
   roomId: string;
   peers: Map<string, Peer>;
   onCopy: () => void;
+  sendMessage: (message: string) => void;
 }
 
 interface MenuItemProps {
@@ -49,6 +50,7 @@ function Panel(props: PanelProps): JSX.Element {
   const [subMenu, setSubMenu] = useState(0);
   const [visible, setVisible] = useState(false);
   const [volume, setVolume] = useState(0);
+  const [message, setMessage] = useState('');
 
   const onClickSubMenu = (e: MenuItemProps) => {
     setVisible(true);
@@ -68,6 +70,15 @@ function Panel(props: PanelProps): JSX.Element {
     volume;
     setVolume(changedVolume);
   };
+  const onMessageInput = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setMessage(e.target.value);
+  };
+  const onSendMessage = (e: React.FormEvent) => {
+    e.preventDefault();
+    const messageData = JSON.stringify({type: 'message', data: message});
+    props.sendMessage(messageData);
+    setMessage('');
+  };
   return (
     <Dropdown
       visible={visible}
@@ -81,7 +92,12 @@ function Panel(props: PanelProps): JSX.Element {
               onClickPrevious: onClickPrevious,
               onChangeVolume: onChangeVolume,
             })
-          : Messenger({...props, onClickPrevious: onClickPrevious})
+          : Messenger({
+              onClickPrevious: onClickPrevious,
+              message: message,
+              onMessageInput: onMessageInput,
+              onSendMessage: onSendMessage,
+            })
       }
       trigger={['click']}
     >

--- a/front/src/components/Panel.tsx
+++ b/front/src/components/Panel.tsx
@@ -5,7 +5,7 @@ import {CopyToClipboard} from 'react-copy-to-clipboard';
 import '../pages/spacePage/space.css';
 import {Peer} from '../utils/RTCGameUtils';
 import {UserInfo, UserList} from './UserList';
-import {Message} from './Message';
+import {Messenger} from './Messenger';
 
 export interface PanelProps {
   getUsers: () => UserInfo[];
@@ -81,7 +81,7 @@ function Panel(props: PanelProps): JSX.Element {
               onClickPrevious: onClickPrevious,
               onChangeVolume: onChangeVolume,
             })
-          : Message({...props, onClickPrevious: onClickPrevious})
+          : Messenger({...props, onClickPrevious: onClickPrevious})
       }
       trigger={['click']}
     >

--- a/front/src/components/SpaceCanvas.tsx
+++ b/front/src/components/SpaceCanvas.tsx
@@ -106,7 +106,9 @@ function SpaceCanvas(props: SpaceCanvasProps): JSX.Element {
       peerManager.me.update(gLHelper);
 
       gLHelper.drawObjectsBeforeAvatar();
-      const data = JSON.stringify(peerManager.me.getPlayerDto());
+      const data = JSON.stringify(
+        Object.assign({type: 'playerDto'}, peerManager.me.getPlayerDto()),
+      );
       peerManager.forEachPeer(peer => {
         peer.transmitUsingDataChannel(data);
         gLHelper.drawAvatar(peer, peer.nicknameDiv);

--- a/front/src/utils/RTCGameUtils.ts
+++ b/front/src/utils/RTCGameUtils.ts
@@ -323,8 +323,17 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
     this.ondatachannel = event => {
       const receviedDC = event.channel;
       receviedDC.onmessage = event => {
-        const data = JSON.parse(event.data) as PlayerDto;
-        this.update(data);
+        // 1. Dto에 타입까지 넣어줘서 조건분기
+        const data = JSON.parse(event.data);
+        if (data.type === 'playerDto') {
+          delete data.type;
+          this.update(data);
+        } else if (data.type === 'message') {
+          console.log(data);
+        }
+        // 2. 뭔가 콜백함수 호출하게?
+        // const data = JSON.parse(event.data) as PlayerDto;
+        // this.update(data);
       };
       receviedDC.onopen = () => {
         console.log(`dataChannel created with ${this.connectedClientSocketID}`);

--- a/front/src/utils/RTCGameUtils.ts
+++ b/front/src/utils/RTCGameUtils.ts
@@ -1,6 +1,7 @@
 import GLHelper from './webGLUtils';
 import {AvatarImageEnum, AvatarPartImageEnum} from './ImageMetaData';
 import RTCSignalingHelper, {IceDto, OfferAnswerDto} from './RTCSignalingHelper';
+import {Message} from '../components/Messenger';
 
 /**
  * position 등 x, y 두 변수를 가지고 있을 때 주로 사용
@@ -270,6 +271,8 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
   //nickname overlay div
   nicknameDiv: HTMLDivElement;
 
+  //onMessageCallback
+  onMessageCallback: (message: Message) => void;
   constructor(
     signalingHelper: RTCSignalingHelper,
     connectedClientSocketID: string,
@@ -278,6 +281,7 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
     nicknameDiv: HTMLDivElement,
     connectionClosedDisconnectedFailedCallBack: (peer: Peer) => void,
     pcConfig: RTCConfiguration,
+    onMessageCallback: (message: Message) => void,
     maxSoundDistance = 500,
   ) {
     super(pcConfig);
@@ -306,6 +310,9 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
     //nickname overlay div
     this.nicknameDiv = nicknameDiv;
 
+    //onMessageCallback
+    this.onMessageCallback = onMessageCallback;
+
     // connect localStream
     localStream.getTracks().forEach(track => {
       this.addTrack(track, localStream);
@@ -330,10 +337,10 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
           this.update(data);
         } else if (data.type === 'message') {
           console.log(data);
+          this.onMessageCallback(data);
+          // 2. 뭔가 콜백함수 호출하게?
+          // onMessageCallBack(data);
         }
-        // 2. 뭔가 콜백함수 호출하게?
-        // const data = JSON.parse(event.data) as PlayerDto;
-        // this.update(data);
       };
       receviedDC.onopen = () => {
         console.log(`dataChannel created with ${this.connectedClientSocketID}`);
@@ -426,6 +433,9 @@ export default class PeerManager {
 
   // RoomID
   readonly roomID: string;
+
+  // DataChannel onMessage callback
+  onMessageCallback: (message: Message) => void;
   constructor(
     signalingHelper: RTCSignalingHelper,
     localStream: MediaStream,
@@ -458,6 +468,11 @@ export default class PeerManager {
     // roomID
     this.roomID = roomID;
 
+    // onMessageCallback
+    this.onMessageCallback = () => {
+      return;
+    };
+
     // setEvent
     this.setSignalingEvent();
 
@@ -467,6 +482,10 @@ export default class PeerManager {
 
   forEachPeer(callback: (peer: Peer) => void): void {
     this.peers.forEach(peer => callback(peer));
+  }
+
+  setOnMessageCallback(onMessageCallback: (message: Message) => void): void {
+    this.onMessageCallback = onMessageCallback;
   }
 
   createNewPeerAndAddPeers(connectedClientSocketID: string): Peer {
@@ -490,6 +509,7 @@ export default class PeerManager {
       nicknameDiv,
       this.connectionClosedDisconnectedFailedCallBack,
       this.pcConfig,
+      this.onMessageCallback,
       500,
     );
     this.peers.set(connectedClientSocketID, peer);

--- a/front/tsconfig.json
+++ b/front/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -16,10 +20,18 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": ["src"],
-  "exclude": ["src/setupTests.ts"],
+  "include": [
+    "src"
+  ],
+  "exclude": [
+    "src/setupTests.ts"
+  ],
   "typedocOptions": {
     "out": "VoiceSpace 프론트앤드",
-    "entryPoints": ["./src/components", "./src/pages", "./src/utils"]
+    "entryPoints": [
+      "./src/components",
+      "./src/pages",
+      "./src/utils"
+    ]
   }
 }


### PR DESCRIPTION
채팅 기능 구현
1. 닉네임 바꾸고 채팅하면 게더나 카카오처럼 과거 내역에 변경된 닉네임 반영 안 됨 -> socketID 받아서 바꿀 수 있도록 변경
2. 아바타 위에 (바람의 나라처럼) 말풍선 띄울 수 있게 추가..할 예정.. ㅎㅎ