### PR TITLE
[SW-178] screenShare 로 오디오까지 같이 보냈을 경우 원래 보내던 마이크오디오가 멈추는 현상 해결

### DIFF
--- a/front/src/components/Navigation.tsx
+++ b/front/src/components/Navigation.tsx
@@ -65,7 +65,7 @@ function Navigation(props: NavigationProps): JSX.Element {
     });
     props.peerManager.forEachPeer(peer => {
       stream.getTracks().forEach(track => {
-        peer.addTrack(track);
+        peer.addTrack(track, stream);
       });
       props.peerManager.peerOffer(peer);
     });

--- a/front/src/components/ScreenShare.tsx
+++ b/front/src/components/ScreenShare.tsx
@@ -355,19 +355,21 @@ function ScreenShare(props: ScreenShareProps): JSX.Element {
   };
 
   const trackEventHandler = (peerId: string, event: RTCTrackEvent) => {
-    if (event.track.kind === 'video') {
-      console.log('trackEventHandler', peerId);
-      const stream = new MediaStream();
-      stream.addTrack(event.track);
+    if (event.streams[0]) {
       setScreenShareDatas(before => {
-        return [
-          {
-            peerId: peerId,
-            stream: stream,
-            drawHelper: new DrawHelper(),
-          },
-          ...before,
-        ];
+        const alreadyExist = before.find(data => {
+          return data.stream.id === event.streams[0].id;
+        });
+        if (alreadyExist) return before;
+        else
+          return [
+            {
+              peerId: peerId,
+              stream: event.streams[0],
+              drawHelper: new DrawHelper(),
+            },
+            ...before,
+          ];
       });
     }
   };

--- a/front/src/utils/RTCGameUtils.ts
+++ b/front/src/utils/RTCGameUtils.ts
@@ -402,7 +402,7 @@ export class Peer extends RTCPeerConnection implements PlayerDto {
     });
 
     this.addEventListener('track', event => {
-      if (event.track.kind === 'audio') {
+      if (!event.streams[0]) {
         const stream = new MediaStream();
         stream.addTrack(event.track);
         this.audio.srcObject = stream;


### PR DESCRIPTION
## 문제   
- Peer 의 track 이벤트에서, audio track 이 도착하면 곧바로 연결된 AudioElement 의 srcObject 를 변경했기 때문에 발생하던 현상이였음.

## 해결
- screenShare 로 video track 과 함께 만들어진 audio track 은 두개를 같이 하나의 stream 으로 묶어 보내고,
- Peer 의 track event 에서는 stream 없이 audio track 만 오면 기존과 같이 AudioElement 의 srcObject 로 바로 연결하고, stream 으로 묶여서 audio track 이 오면 trackEventHandler 를 통해 처리하는 것으로 해결