### PR TITLE
[SW-229][bugfix]화면 아래 맵 튀어나오던 현상 수정

### DIFF
--- a/front/src/utils/pixiUtils/GameScene.ts
+++ b/front/src/utils/pixiUtils/GameScene.ts
@@ -18,7 +18,10 @@ export class GameScene extends Container implements Scene {
     const world = new World(world1Json);
     this.world = world;
     //viewport create
-    const viewport = createViewport(world.width, world.height);
+    const viewport = createViewport(
+      world.background.width,
+      world.background.height,
+    );
     this.viewport = viewport;
     //worldsetViewport
     world.setViewport(viewport);

--- a/front/src/utils/pixiUtils/PixiCanvas.ts
+++ b/front/src/utils/pixiUtils/PixiCanvas.ts
@@ -4,7 +4,7 @@ import {ResourceManager} from './ResourceManager';
 import resourceUrls from './metaData/resourcesUrl.json';
 
 export function pixiCanvasStart(): void {
-  SceneManager.initialize(0x552227);
+  SceneManager.initialize(0x689f38);
   ResourceManager.loadResourcesFrom(resourceUrls);
   ResourceManager.setOnErrorCallback(error => {
     console.log(error);


### PR DESCRIPTION
- World의 background 를 벗어나는 Stuff 존재 시 월드의 width, height가 해당 Stuff를 포함하는 사이즈로 변경됨(Container 이기 때문)
- viewport의 world width, height를 설정할 때, world.background.width , world.background.height 를 적용함