### PR TITLE
[SW-251][bugfix]DisplayContainer collidable 껐다 켰다 가능하도록 해서 해결

### DIFF
--- a/front/src/utils/pixiUtils/DisplayContainer.ts
+++ b/front/src/utils/pixiUtils/DisplayContainer.ts
@@ -70,4 +70,12 @@ export class DisplayContainer extends Container {
     sprite.anchor.set(part.anchor.x, part.anchor.y);
     return sprite;
   }
+
+  offCollidable(): void {
+    this.collidable = false;
+  }
+
+  onCollidable(): void {
+    this.collidable = true;
+  }
 }

--- a/front/src/utils/pixiUtils/MyAvatar.ts
+++ b/front/src/utils/pixiUtils/MyAvatar.ts
@@ -75,7 +75,7 @@ export class MyAvatar extends Avatar {
 
     this.x += this.vx * delta;
     this.y += this.vy * delta;
-    if (this.isCollided(this.world)) {
+    if (this.collidable && this.isCollided(this.world)) {
       this.x = oldX;
       this.y = oldY;
     }
@@ -125,7 +125,8 @@ export class MyAvatar extends Avatar {
     for (let i = 1; i < stuffs.length; ++i) {
       if (
         !(this === stuffs[i]) &&
-        stuffs[i].collisionBox &&
+        this.collidable &&
+        stuffs[i].collidable &&
         checkIntersect(
           this.collisionBox as DisplayObject,
           stuffs[i].collisionBox as DisplayObject,

--- a/front/src/utils/pixiUtils/PeerAvatar.ts
+++ b/front/src/utils/pixiUtils/PeerAvatar.ts
@@ -98,8 +98,4 @@ export class PeerAvatar extends Avatar {
     }
     return;
   }
-
-  public removeCollisionBox(): void {
-    this.collisionBox = null;
-  }
 }

--- a/front/src/utils/pixiUtils/World.ts
+++ b/front/src/utils/pixiUtils/World.ts
@@ -105,7 +105,7 @@ export class World extends Container implements IWorld {
       return;
     }
     newPeer.setAvatar(peerAvatarImageEnum);
-    newPeer.removeCollisionBox();
+    newPeer.offCollidable();
     this.addChild(newPeer);
     this.peers.set(socketID, newPeer);
   }


### PR DESCRIPTION
- 충돌판정은 모든 DisplayContainer가 가지고있는 collidable:boolean, collisionBox:CollisionBox 두가지 멤버를 이용해서 처리되는데,
- PeerAvatar는 생성 후 collidable 속성을 꺼주는 방식으로 해결하였음