### PR TITLE
[bugfix] spaceLoading 에서 birdImg 가 가끔씩 순간이동 하는 버그 해결

### DIFF
--- a/front/src/components/SpaceLoading.tsx
+++ b/front/src/components/SpaceLoading.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect} from 'react';
 import {Progress} from 'antd';
 import './spaceLoading.css';
 
@@ -25,18 +25,8 @@ class LoadingMessageProvider {
 }
 
 function SpaceLoading(props: SpaceLoadingProps): JSX.Element {
-  const loadingImgRef = useRef<HTMLImageElement>(null);
   const progressBarWidth = 230;
-
-  useEffect(() => {
-    if (loadingImgRef.current) {
-      const img = loadingImgRef.current;
-      const leftShiftValue =
-        (progressBarWidth / 100) * props.loadingPercentage -
-        (progressBarWidth / 2 + img.width / 2);
-      img.style.left = `calc(50% + ${leftShiftValue}px`;
-    }
-  }, [props.loadingPercentage]);
+  const birdImgWidth = 50;
 
   useEffect(() => {
     LoadingMessageProvider.shuffleMessage();
@@ -52,7 +42,13 @@ function SpaceLoading(props: SpaceLoadingProps): JSX.Element {
         {props.message ? props.message : LoadingMessageProvider.message}
       </div>
       <img
-        ref={loadingImgRef}
+        style={{
+          left: `calc(50% + ${
+            (progressBarWidth / 100) * props.loadingPercentage -
+            (progressBarWidth / 2 + birdImgWidth / 2)
+          }px`,
+          width: birdImgWidth,
+        }}
         className="loadingImg"
         src="./assets/spaceMain/loading/forestBird.png"
       ></img>

--- a/front/src/components/spaceLoading.css
+++ b/front/src/components/spaceLoading.css
@@ -46,7 +46,6 @@
   transform: translate(-50%, -50%);
   animation: rotateImage 0.15s linear infinite;
   transform-origin: 50% 50%;
-  width: 50px;
   height: 50px;
 }
 


### PR DESCRIPTION
- img 가 모두 rendering 된 후 , useEffect 의 콜백 안에서 해당 img 의
좌표값을 다시 변경하던 방식에서,
- 좌표값을 먼저 계산하고 렌더링하는 방식으로 변경되었습니다.
- 아무래도 콜백이다 보니 콜스택에 먼저 들어갔다고 해서 항상 먼저 끝나는
것이 아니라서
- 66% 의 값으로 실행된 콜백이 33%의 값으로 실행된 콜백보다 먼저 완료되는
케 이스에서
- 뒤로 가는 버그가 존재하였던 것 같습니다